### PR TITLE
QuotedPrintable support - to process input when a QuotedPrintable encoded field spans multiple lines

### DIFF
--- a/VisualCard.sln
+++ b/VisualCard.sln
@@ -25,9 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Public", "Public", "{F07A71
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VisualCard.ShowCalendars", "VisualCard.ShowCalendars\VisualCard.ShowCalendars.csproj", "{80A3B32A-F96E-4E87-837F-94E6EB188547}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VisualCard.Extras", "VisualCard.Extras\VisualCard.Extras.csproj", "{A06611BC-20E0-4990-B907-83C2979E5AE8}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualCardTester", "VisualCardTester\VisualCardTester.csproj", "{D38D9034-43C2-4584-97AE-D19B8F558F39}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualCard.Extras", "VisualCard.Extras\VisualCard.Extras.csproj", "{A06611BC-20E0-4990-B907-83C2979E5AE8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,10 +57,6 @@ Global
 		{A06611BC-20E0-4990-B907-83C2979E5AE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A06611BC-20E0-4990-B907-83C2979E5AE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A06611BC-20E0-4990-B907-83C2979E5AE8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D38D9034-43C2-4584-97AE-D19B8F558F39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D38D9034-43C2-4584-97AE-D19B8F558F39}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D38D9034-43C2-4584-97AE-D19B8F558F39}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D38D9034-43C2-4584-97AE-D19B8F558F39}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/VisualCard.sln
+++ b/VisualCard.sln
@@ -25,7 +25,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Public", "Public", "{F07A71
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VisualCard.ShowCalendars", "VisualCard.ShowCalendars\VisualCard.ShowCalendars.csproj", "{80A3B32A-F96E-4E87-837F-94E6EB188547}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualCard.Extras", "VisualCard.Extras\VisualCard.Extras.csproj", "{A06611BC-20E0-4990-B907-83C2979E5AE8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VisualCard.Extras", "VisualCard.Extras\VisualCard.Extras.csproj", "{A06611BC-20E0-4990-B907-83C2979E5AE8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualCardTester", "VisualCardTester\VisualCardTester.csproj", "{D38D9034-43C2-4584-97AE-D19B8F558F39}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +59,10 @@ Global
 		{A06611BC-20E0-4990-B907-83C2979E5AE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A06611BC-20E0-4990-B907-83C2979E5AE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A06611BC-20E0-4990-B907-83C2979E5AE8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D38D9034-43C2-4584-97AE-D19B8F558F39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D38D9034-43C2-4584-97AE-D19B8F558F39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D38D9034-43C2-4584-97AE-D19B8F558F39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D38D9034-43C2-4584-97AE-D19B8F558F39}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/VisualCard/CardTools.cs
+++ b/VisualCard/CardTools.cs
@@ -103,6 +103,14 @@ namespace VisualCard
                     var prop = new PropertyInfo(CardLine);
                     prefix = prop.Prefix;
                     value = prop.Value;
+                    while (prop.Continue)
+                    {
+                        string nextLine = stream.ReadLine();
+
+                        prop.AddLine(nextLine);
+                        //Add it to the current line for later processing
+                        CardLine += nextLine;
+                    }
                 }
                 catch
                 {

--- a/VisualCard/Parsers/Arguments/PropertyInfo.cs
+++ b/VisualCard/Parsers/Arguments/PropertyInfo.cs
@@ -33,6 +33,7 @@ namespace VisualCard.Parsers.Arguments
     public class PropertyInfo : IEquatable<PropertyInfo?>
     {
         private readonly string rawValue = "";
+        private string tailValue = "";
         private readonly string prefix = "";
         private readonly string group = "";
         private readonly ArgumentInfo[] arguments = [];
@@ -41,7 +42,7 @@ namespace VisualCard.Parsers.Arguments
         /// Raw value
         /// </summary>
         public string Value =>
-            rawValue;
+            rawValue + tailValue;
 
         /// <summary>
         /// Property prefix
@@ -66,6 +67,11 @@ namespace VisualCard.Parsers.Arguments
         /// </summary>
         public ArgumentInfo[] Arguments =>
             arguments;
+
+        /// <summary>
+        /// Specifies if this property spans multiple lines
+        /// </summary>
+        public bool Multiline { get; set; }
 
         /// <summary>
         /// Checks to see if both the property info instances are equal
@@ -117,6 +123,19 @@ namespace VisualCard.Parsers.Arguments
         public static bool operator !=(PropertyInfo? left, PropertyInfo? right) =>
             !(left == right);
 
+        internal static string Encoding(ArgumentInfo[] args)
+            => VcardCommonTools.GetValuesString(args, "", VcardConstants._encodingArgumentSpecifier);
+
+        /// <inheritdoc/>
+        public bool Continue
+            => Multiline ? (0 < Value?.Length ? '=' == Value[Value.Length - 1] : false) : false;
+
+        /// <inheritdoc/>
+        public void AddLine(string line)
+        {
+            tailValue += line;
+        }
+
         internal PropertyInfo(string line)
         {
             // Now, parse this value
@@ -142,6 +161,10 @@ namespace VisualCard.Parsers.Arguments
             this.rawValue = value;
             this.prefix = prefix;
             this.arguments = finalArgs;
+            if (VcardConstants._quotedPrintable == Encoding(this.arguments))
+                Multiline = true;
+            else
+                Multiline = false;
             this.group = group.Trim();
         }
     }

--- a/VisualCard/Parsers/VcardConstants.cs
+++ b/VisualCard/Parsers/VcardConstants.cs
@@ -35,6 +35,9 @@ namespace VisualCard.Parsers
         internal const string _spaceBreak = " ";
         internal const string _tabBreak = "\x0009";
 
+        //Encodings
+        internal const string _quotedPrintable = "QUOTED-PRINTABLE";
+
         // Available in vCard 2.1, 3.0, 4.0, and 5.0
         internal const char _fieldDelimiter = ';';
         internal const char _valueDelimiter = ',';


### PR DESCRIPTION
## Description
Added logic to minimally support the QuotedPrintable encoding.  The QuotedPrintable encoding may span multiple lines. If so, the new logic will read all the lines of that field into the value of that property. It does not decode the encoding. 

The new logic does not check for vCard version. The QuotedPrintable encoding are not supported in version 3.0 and later. I'm not sure if we wanted to be permissable or adhere strictly to the specification. If we want to be strict, we should add a check for version (I'm happy to add that if desired).

## Change type
- [x] Feature changes: When reading a property value into PropertyInfo, check for the encoding. If multiple lines are supported, keep appending the lines from the stream into the PropertyInfo.
- [x] Behavioral changes: Added a property and a field to PropertyInfo. The 'MultiLine' property is true if the encoding for the current field potentially spans multiple lines. The 'tailValue' field is added to the rawValue field when retrieving the value for the PropertyInfo.

## Tested?
<!-- Have you tested your changes? -->
- [x] Yes, I have

## Other changes?
Shouldn't be any.
